### PR TITLE
Improve Codec Arguments

### DIFF
--- a/src/codecs.json
+++ b/src/codecs.json
@@ -1,11 +1,11 @@
 {"codecs":[
         {
-        "x264":"-c:v libx264 -preset medium -pix_fmt yuv420p -crf 18",
-        "x265":"-c:v libx265 -preset medium -pix_fmt yuv420p -crf 20",
-        "AV1":"-c:v libsvtav1 -preset 9 -crf 20 -svtav1-params tune=0:enable-tf=0:enable-overlays=1 -pix_fmt yuv420p10le",
-        "VP9":"-c:v libvpx-vp9 -b:v 0 -crf 18 -cpu-used 3 -aq-mode 1 -pix_fmt yuv420p10le",
+        "x264":"-c:v libx264 -preset slow -x264-params direct=spatial -pix_fmt yuv420p -qp 16",
+        "x265":"-c:v libx265 -preset medium -pix_fmt yuv420p -qp 18",
+        "AV1":"-c:v libsvtav1 -preset 8 -qp 20 -svtav1-params tune=0:enable-tf=0:enable-overlays=1 -pix_fmt yuv420p10le",
+        "VP9":"-c:v libvpx-vp9 -b:v 0 -crf 18 -cpu-used 3 -aq-mode 1 -pix_fmt yuv420p",
         "ProRes":"-c:v prores_ks -profile:v 4 -vendor apl0 -bits_per_mb 8000 -pix_fmt yuva444p10le",
-        "NVENC":"-c:v hevc_nvenc -preset p7 -cq 20"
+        "NVENC":"-c:v hevc_nvenc -preset p6 -qp 20"
         }
     ]
 }


### PR DESCRIPTION
This Merge request makes the following changes
#### x264
- Increased preset from medium to slow
- Uses preset medium's direct argument for minor speed up
- Switched to qp instead of crf to improve generation loss
- Dropped quality level to 16 to avoid obvious artifacts
#### x265
- Switched to qp instead of crf to improve generation loss
#### AV1
- Dropped down to preset 8 for smaller output size
- Switched to qp instead of crf to improve generation loss
#### VP9
- Switched to yuv420p as not all vp9 hardware decoders and software support 10bit
#### NVENC
- Dropped down to preset 6 for large speed up and almost no quality loss
- Switched to qp instead of crf to improve generation loss

Overall this should be a negligible performance decrease or in some case performance gain for better quality. This should also fix VP9 playback with some hardware and media players