### PR TITLE
Update Codec arguments

### DIFF
--- a/src/codecs.json
+++ b/src/codecs.json
@@ -1,7 +1,7 @@
 {"codecs":[
         {
-            "x264":"-c:v libx264 -crf 16 -preset slow -x264-params direct=spatial:me=umh -pix_fmt yuv420p",
-            "x265":"-c:v libx265 -crf 18 -preset medium -pix_fmt yuv420p",
+            "x264":"-c:v libx264 -qp 16 -preset medium -pix_fmt yuv420p",
+            "x265":"-c:v libx265 -qp 18 -preset medium -pix_fmt yuv420p",
             "AV1":"-c:v libsvtav1 -qp 20 -preset 7 -svtav1-params tune=0:enable-tf=0:enable-overlays=1:enable-qm=1 -pix_fmt yuv420p10le",
             "VP9":"-c:v libvpx-vp9 -b:v 0 -crf 18 -cpu-used 3 -aq-mode 1 -pix_fmt yuv420p",
             "ProRes":"-c:v prores_ks -profile:v 4 -vendor apl0 -bits_per_mb 8000 -pix_fmt yuva444p10le",


### PR DESCRIPTION
This commit reverts back to using QP and uses a faster preset for x264. QP has far better generation loss compared to CRF as well as not being that much of a hit in efficiency. QP is also faster as it disables some mode decisions within the encoder. The preset was lowered back down to medium for x264 because "my cpu dying since ur presets".