### PR TITLE
Replace invalid discord link with dsc.gg/enhancr

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,4 +157,4 @@ I am continuously working to improve the codebase, including addressing any inco
 
 # Join the discord
 
-To interact with the community, share your results or to get help when encountering any problems visit our [discord](https://discord.gg/jBDqCkSxYz). Previews of upcoming versions are gonna be showcased on there as well.
+To interact with the community, share your results or to get help when encountering any problems visit our [discord](https://dsc.gg/enhancr). Previews of upcoming versions are gonna be showcased on there as well.


### PR DESCRIPTION
Well, it says it's invalid but for some reason the first time i tried it, invited me to some scam server. This replacement link leads me to the right server.